### PR TITLE
DNM: add release-6.6 for tidb

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -7,6 +7,7 @@
           "repo": "pingcap/docs",
           "versions": [
             "master",
+            "release-6.6",
             "release-6.5",
             "release-6.4",
             "release-6.3",
@@ -24,6 +25,7 @@
           "repo": "pingcap/docs-cn",
           "versions": [
             "master",
+            "release-6.6",
             "release-6.5",
             "release-6.4",
             "release-6.3",
@@ -40,6 +42,7 @@
         "ja": {
           "repo": "pingcap/docs",
           "versions": [
+            "release-6.6",
             "release-6.5",
             "release-6.4",
             "release-6.3",
@@ -59,7 +62,7 @@
         "v5.3",
         "v5.4"
       ],
-      "dmr": ["v6.4", "v6.3", "v6.2", "v6.0"],
+      "dmr": ["v6.6, v6.4", "v6.3", "v6.2", "v6.0"],
       "archived": ["v6.2", "v6.0", "v3.1", "v2.1"]
     },
     "tidb-data-migration": {


### PR DESCRIPTION
Do not merge this PR until this v6.6 docs are published.