### PR TITLE
docs.json: add release-7.1 as LTS for TiDB

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -64,7 +64,7 @@
       ],
       "dmr": ["v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0"],
       "archived": ["v6.4", "v6.3", "v6.2", "v6.0", "v3.1", "v2.1"],
-      "searchIndex": ["v6.5", "v6.1", "v5.4", "v5.1"]
+      "searchIndex": ["v7.1", "v6.5", "v6.1", "v5.4", "v5.1"]
     },
     "tidb-data-migration": {
       "languages": {

--- a/docs.json
+++ b/docs.json
@@ -1,12 +1,13 @@
 {
   "docs": {
     "tidb": {
-      "stable": "release-6.5",
+      "stable": "release-7.1",
       "languages": {
         "en": {
           "repo": "pingcap/docs",
           "versions": [
             "master",
+            "release-7.1",
             "release-7.0",
             "release-6.6",
             "release-6.5",
@@ -24,6 +25,7 @@
           "repo": "pingcap/docs-cn",
           "versions": [
             "master",
+            "release-7.1",
             "release-7.0",
             "release-6.6",
             "release-6.5",
@@ -40,6 +42,7 @@
         "ja": {
           "repo": "pingcap/docs",
           "versions": [
+            "release-7.1",
             "release-7.0",
             "release-6.6",
             "release-6.5",


### PR DESCRIPTION
- Add release-7.1 for TiDB docs
- Do not merge this PR until v7.1 docs are published on 2023/05/31.