### PR TITLE
chore(workflow): update "CI" workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -22,6 +22,8 @@ on:
         default: false
         required: false
 
+concurrency: ${{ github.workflow }}
+
 jobs:
   build:
     concurrency: update-${{ inputs.repo }}-${{ inputs.branch }}


### PR DESCRIPTION
This PR uses `concurrency` to ensure that only a single workflow using the "CI" concurrency group will run at a time.