### PR TITLE
main: archive v7.0 docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -10,7 +10,6 @@
             "release-7.3",
             "release-7.2",
             "release-7.1",
-            "release-7.0",
             "release-6.5",
             "release-6.1",
             "release-5.4",
@@ -29,7 +28,6 @@
             "release-7.3",
             "release-7.2",
             "release-7.1",
-            "release-7.0",
             "release-6.5",
             "release-6.1",
             "release-5.4",
@@ -47,7 +45,6 @@
             "release-7.3",
             "release-7.2",
             "release-7.1",
-            "release-7.0",
             "release-6.5",
             "release-6.1",
             "release-5.4"
@@ -66,7 +63,7 @@
         "v5.4"
       ],
       "dmr": ["v7.3", "v7.2", "v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0"],
-      "archived": ["v6.6", "v6.4", "v6.3", "v6.2", "v6.0", "v3.1", "v2.1"],
+      "archived": ["v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0", "v3.1", "v2.1"],
       "searchIndex": ["v7.1", "v6.5", "v6.1", "v5.4", "v5.1"]
     },
     "tidb-data-migration": {


### PR DESCRIPTION
- Update doc.json to move v7.0 to the archive list 
- [ToDo] Remove v7.0 docs from markdown-pages