### PR TITLE
fix(packages/download): add an error handler

### DIFF
--- a/packages/download/http.js
+++ b/packages/download/http.js
@@ -68,6 +68,11 @@ export function downloadFile(reqUrl, fileName = '') {
             sig.success('download completed')
             resolve()
           })
+
+          res.data.on('error', () => {
+            sig.error('Failed to save file: ', err)
+            reject()
+          })
         })
       } else {
         sig.error(`ERROR >> ${res.status}`)

--- a/packages/download/http.js
+++ b/packages/download/http.js
@@ -69,7 +69,7 @@ export function downloadFile(reqUrl, fileName = '') {
             resolve()
           })
 
-          res.data.on('error', () => {
+          res.data.on('error', (err) => {
             sig.error('Failed to save file: ', err)
             reject()
           })


### PR DESCRIPTION
This PR adds an error handler for `downloadFile` in `download/http` script.