### PR TITLE
archive: add v3.0 and v7.2 docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -7,8 +7,8 @@
           "repo": "pingcap/docs",
           "versions": [
             "master",
+            "release-7.4",
             "release-7.3",
-            "release-7.2",
             "release-7.1",
             "release-6.5",
             "release-6.1",
@@ -17,16 +17,15 @@
             "release-5.2",
             "release-5.1",
             "release-5.0",
-            "release-4.0",
-            "release-3.0"
+            "release-4.0"
           ]
         },
         "zh": {
           "repo": "pingcap/docs-cn",
           "versions": [
             "master",
+            "release-7.4",
             "release-7.3",
-            "release-7.2",
             "release-7.1",
             "release-6.5",
             "release-6.1",
@@ -35,15 +34,14 @@
             "release-5.2",
             "release-5.1",
             "release-5.0",
-            "release-4.0",
-            "release-3.0"
+            "release-4.0"
           ]
         },
         "ja": {
           "repo": "pingcap/docs",
           "versions": [
+            "release-7.4",
             "release-7.3",
-            "release-7.2",
             "release-7.1",
             "release-6.5",
             "release-6.1",
@@ -62,8 +60,8 @@
         "v5.3",
         "v5.4"
       ],
-      "dmr": ["v7.3", "v7.2", "v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0"],
-      "archived": ["v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0", "v3.1", "v2.1"],
+      "dmr": ["v7.4", "v7.3", "v7.2", "v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0"],
+      "archived": ["v7.2", "v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0", "v3.1", "v3.0", "v2.1"],
       "searchIndex": ["v7.1", "v6.5", "v6.1", "v5.4", "v5.1"]
     },
     "tidb-data-migration": {
@@ -119,6 +117,12 @@
             "pathname": "v1beta",
             "production": "https://download.pingcap.org/tidbcloud-oas.json",
             "preview": "https://download.pingcap.org/tidbcloud-oas-preview.json"
+          },
+          {
+            "id": "v1beta1",
+            "pathname": "v1beta1",
+            "production": "https://download.pingcap.org/tidbcloud-oas-v1beta1-billing.swagger.json",
+            "preview": "https://download.pingcap.org/tidbcloud-oas-v1beta1-billing.swagger.json"
           }
         ]
       }

--- a/markdown-pages/en/tidb/_docHome.md
+++ b/markdown-pages/en/tidb/_docHome.md
@@ -20,6 +20,8 @@ hide_leftNav: true
 
 | Release    | Archived documentation                                         | Archive date     |
 | ---------- | -------------------------------------------------------------- | ---------------- |
+| v7.2 (DMR) | [TiDB v7.2 documentation](https://docs-archive.pingcap.com/tidb/v7.2/) | October 20, 2023 |
+| v3.0       | [TiDB v3.0 documentation](https://docs-archive.pingcap.com/tidb/v3.0/) | October 20, 2023 |
 | v7.0 (DMR) | [TiDB v7.0 documentation](https://docs-archive.pingcap.com/tidb/v7.0/) | August 24, 2023 |
 | v6.6 (DMR) | [TiDB v6.6 documentation](https://docs-archive.pingcap.com/tidb/v6.6/) | July 7, 2023 |
 | v6.4 (DMR) | [TiDB v6.4 documentation](https://docs-archive.pingcap.com/tidb/v6.4/) | April 6, 2023 |

--- a/markdown-pages/en/tidb/_docHome.md
+++ b/markdown-pages/en/tidb/_docHome.md
@@ -21,7 +21,6 @@ hide_leftNav: true
 | Release    | Archived documentation                                         | Archive date     |
 | ---------- | -------------------------------------------------------------- | ---------------- |
 | v7.2 (DMR) | [TiDB v7.2 documentation](https://docs-archive.pingcap.com/tidb/v7.2/) | October 20, 2023 |
-| v3.0       | [TiDB v3.0 documentation](https://docs-archive.pingcap.com/tidb/v3.0/) | October 20, 2023 |
 | v7.0 (DMR) | [TiDB v7.0 documentation](https://docs-archive.pingcap.com/tidb/v7.0/) | August 24, 2023 |
 | v6.6 (DMR) | [TiDB v6.6 documentation](https://docs-archive.pingcap.com/tidb/v6.6/) | July 7, 2023 |
 | v6.4 (DMR) | [TiDB v6.4 documentation](https://docs-archive.pingcap.com/tidb/v6.4/) | April 6, 2023 |
@@ -29,7 +28,8 @@ hide_leftNav: true
 | v6.2 (DMR) | [TiDB v6.2 documentation](https://docs-archive.pingcap.com/tidb/v6.2/) | January 31, 2023 |
 | v6.0 (DMR) | [TiDB v6.0 documentation](https://docs-archive.pingcap.com/tidb/v6.0/) | January 31, 2023 |
 | v3.1       | [TiDB v3.1 documentation](https://docs-archive.pingcap.com/tidb/v3.1/) | January 31, 2023 |
-| v2.1       | [TiDB v2.1 documentation](https://docs-archive.pingcap.com/tidb/v2.1) | January 31, 2023 |
+| v3.0       | [TiDB v3.0 documentation](https://docs-archive.pingcap.com/tidb/v3.0/) | October 20, 2023 |
+| v2.1       | [TiDB v2.1 documentation](https://docs-archive.pingcap.com/tidb/v2.1)  | January 31, 2023 |
 
 <p>Learn more about <a href="https://www.pingcap.com/tidb-release-support-policy/?from=en">TiDB Release Support Policy</a>.</p>
 

--- a/markdown-pages/zh/tidb/_docHome.md
+++ b/markdown-pages/zh/tidb/_docHome.md
@@ -20,6 +20,8 @@ hide_leftNav: true
 
 | 版本        | 归档文档链接                                             | 归档日期 |
 | ---------- | ------------------------------------------------------ | ----------------- |
+| v7.2 (DMR) | [TiDB v7.2 文档](https://docs-archive.pingcap.com/zh/tidb/v7.2) | 2023 年 10 月 20 日 |
+| v3.0       | [TiDB v3.0 文档](https://docs-archive.pingcap.com/zh/tidb/v3.0) | 2023 年 10 月 20 日 |
 | v7.0 (DMR) | [TiDB v7.0 文档](https://docs-archive.pingcap.com/zh/tidb/v7.0) | 2023 年 8 月 24 日 |
 | v6.6 (DMR) | [TiDB v6.6 文档](https://docs-archive.pingcap.com/zh/tidb/v6.6) | 2023 年 7 月 7 日 |
 | v6.4 (DMR) | [TiDB v6.4 文档](https://docs-archive.pingcap.com/zh/tidb/v6.4) | 2023 年 4 月 6 日 |

--- a/markdown-pages/zh/tidb/_docHome.md
+++ b/markdown-pages/zh/tidb/_docHome.md
@@ -21,15 +21,15 @@ hide_leftNav: true
 | 版本        | 归档文档链接                                             | 归档日期 |
 | ---------- | ------------------------------------------------------ | ----------------- |
 | v7.2 (DMR) | [TiDB v7.2 文档](https://docs-archive.pingcap.com/zh/tidb/v7.2) | 2023 年 10 月 20 日 |
+| v7.0 (DMR) | [TiDB v7.0 文档](https://docs-archive.pingcap.com/zh/tidb/v7.0) | 2023 年 8 月 24 日  |
+| v6.6 (DMR) | [TiDB v6.6 文档](https://docs-archive.pingcap.com/zh/tidb/v6.6) | 2023 年 7 月 7 日   |
+| v6.4 (DMR) | [TiDB v6.4 文档](https://docs-archive.pingcap.com/zh/tidb/v6.4) | 2023 年 4 月 6 日   |
+| v6.3 (DMR) | [TiDB v6.3 文档](https://docs-archive.pingcap.com/zh/tidb/v6.3) | 2023 年 2 月 24 日  |
+| v6.2 (DMR) | [TiDB v6.2 文档](https://docs-archive.pingcap.com/zh/tidb/v6.2) | 2023 年 1 月 31 日  |
+| v6.0 (DMR) | [TiDB v6.0 文档](https://docs-archive.pingcap.com/zh/tidb/v6.0) | 2023 年 1 月 31 日  |
+| v3.1       | [TiDB v3.1 文档](https://docs-archive.pingcap.com/zh/tidb/v3.1) | 2023 年 1 月 31 日  |
 | v3.0       | [TiDB v3.0 文档](https://docs-archive.pingcap.com/zh/tidb/v3.0) | 2023 年 10 月 20 日 |
-| v7.0 (DMR) | [TiDB v7.0 文档](https://docs-archive.pingcap.com/zh/tidb/v7.0) | 2023 年 8 月 24 日 |
-| v6.6 (DMR) | [TiDB v6.6 文档](https://docs-archive.pingcap.com/zh/tidb/v6.6) | 2023 年 7 月 7 日 |
-| v6.4 (DMR) | [TiDB v6.4 文档](https://docs-archive.pingcap.com/zh/tidb/v6.4) | 2023 年 4 月 6 日 |
-| v6.3 (DMR) | [TiDB v6.3 文档](https://docs-archive.pingcap.com/zh/tidb/v6.3) | 2023 年 2 月 24 日 |
-| v6.2 (DMR) | [TiDB v6.2 文档](https://docs-archive.pingcap.com/zh/tidb/v6.2) | 2023 年 1 月 31 日 |
-| v6.0 (DMR) | [TiDB v6.0 文档](https://docs-archive.pingcap.com/zh/tidb/v6.0) | 2023 年 1 月 31 日 |
-| v3.1       | [TiDB v3.1 文档](https://docs-archive.pingcap.com/zh/tidb/v3.1) | 2023 年 1 月 31 日 |
-| v2.1       | [TiDB v2.1 文档](https://docs-archive.pingcap.com/zh/tidb/v2.1) | 2023 年 1 月 31 日 |
+| v2.1       | [TiDB v2.1 文档](https://docs-archive.pingcap.com/zh/tidb/v2.1) | 2023 年 1 月 31 日  |
 
 <p>了解 <a href="https://cn.pingcap.com/tidb-release-support-policy/">TiDB 版本周期支持策略详情</a>。</p>
 


### PR DESCRIPTION
1. Add v3.0 and v7.2 to the home page of the Archive Docs website.
2. Update the version selection list on the Archive Docs website.