### PR TITLE
docs.json: add release-7.5 as LTS for TiDB

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -42,13 +42,13 @@ jobs:
           mkdir -p ./preview/markdown-pages/zh/tidb
 
           cp -rip ./main/markdown-pages/en/tidb/master ./preview/markdown-pages/en/tidb/master
-          cp -rip ./main/markdown-pages/en/tidb/release-7.1 ./preview/markdown-pages/en/tidb/release-7.1
+          cp -rip ./main/markdown-pages/en/tidb/release-7.5 ./preview/markdown-pages/en/tidb/release-7.5
           cp -rip ./main/markdown-pages/en/tidbcloud ./preview/markdown-pages/en/
 
-          cp -rip ./main/markdown-pages/zh/tidb/release-7.1 ./preview/markdown-pages/zh/tidb/release-7.1
+          cp -rip ./main/markdown-pages/zh/tidb/release-7.5 ./preview/markdown-pages/zh/tidb/release-7.5
           cp -rip ./main/markdown-pages/zh/tidb/master ./preview/markdown-pages/zh/tidb/master
 
-          cp -rip ./main/markdown-pages/ja/tidb/release-7.1 ./preview/markdown-pages/ja/tidb/release-7.1
+          cp -rip ./main/markdown-pages/ja/tidb/release-7.5 ./preview/markdown-pages/ja/tidb/release-7.5
           cp -rip ./main/markdown-pages/ja/tidbcloud ./preview/markdown-pages/ja/
 
       - name: Git commit and push

--- a/docs.json
+++ b/docs.json
@@ -1,12 +1,13 @@
 {
   "docs": {
     "tidb": {
-      "stable": "release-7.1",
+      "stable": "release-7.5",
       "languages": {
         "en": {
           "repo": "pingcap/docs",
           "versions": [
             "master",
+            "release-7.5",
             "release-7.4",
             "release-7.3",
             "release-7.1",
@@ -24,6 +25,7 @@
           "repo": "pingcap/docs-cn",
           "versions": [
             "master",
+            "release-7.5",
             "release-7.4",
             "release-7.3",
             "release-7.1",
@@ -40,6 +42,7 @@
         "ja": {
           "repo": "pingcap/docs",
           "versions": [
+            "release-7.5",
             "release-7.4",
             "release-7.3",
             "release-7.1",
@@ -62,7 +65,7 @@
       ],
       "dmr": ["v7.4", "v7.3", "v7.2", "v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0"],
       "archived": ["v7.2", "v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0", "v3.1", "v3.0", "v2.1"],
-      "searchIndex": ["v7.1", "v6.5", "v6.1", "v5.4", "v5.1"]
+      "searchIndex": ["v7.5", "v7.1", "v6.5", "v6.1", "v5.4", "v5.1"]
     },
     "tidb-data-migration": {
       "languages": {


### PR DESCRIPTION
- Add release-7.5 for TiDB docs
- Do not merge this PR until v7.5 docs are published on 2023/12/01.