### PR TITLE
DNM: add release-7.6 for tidb 

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -7,6 +7,7 @@
           "repo": "pingcap/docs",
           "versions": [
             "master",
+            "release-7.6",
             "release-7.5",
             "release-7.4",
             "release-7.3",
@@ -25,6 +26,7 @@
           "repo": "pingcap/docs-cn",
           "versions": [
             "master",
+            "release-7.6",
             "release-7.5",
             "release-7.4",
             "release-7.3",
@@ -42,6 +44,7 @@
         "ja": {
           "repo": "pingcap/docs",
           "versions": [
+            "release-7.6",
             "release-7.5",
             "release-7.4",
             "release-7.3",
@@ -63,7 +66,7 @@
         "v5.3",
         "v5.4"
       ],
-      "dmr": ["v7.4", "v7.3", "v7.2", "v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0"],
+      "dmr": ["v7.6", "v7.4", "v7.3", "v7.2", "v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0"],
       "archived": ["v7.2", "v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0", "v3.1", "v3.0", "v2.1"],
       "searchIndex": ["v7.5", "v7.1", "v6.5", "v6.1", "v5.4", "v5.1"]
     },


### PR DESCRIPTION
Do not merge this PR until v7.6 docs are published tomorrow.