### PR TITLE
add release-8.2 for TiDB docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -7,6 +7,7 @@
           "repo": "pingcap/docs",
           "versions": [
             "master",
+            "release-8.2",
             "release-8.1",
             "release-8.0",
             "release-7.6",
@@ -24,6 +25,7 @@
           "repo": "pingcap/docs-cn",
           "versions": [
             "master",
+            "release-8.2",
             "release-8.1",
             "release-8.0",
             "release-7.6",
@@ -40,6 +42,7 @@
         "ja": {
           "repo": "pingcap/docs",
           "versions": [
+            "release-8.2",
             "release-8.1",
             "release-8.0",
             "release-7.6",
@@ -62,7 +65,7 @@
         "v5.3",
         "v5.4"
       ],
-      "dmr": ["v8.0", "v7.6", "v7.4", "v7.3", "v7.2", "v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0"],
+      "dmr": ["v8.2", "v8.0", "v7.6", "v7.4", "v7.3", "v7.2", "v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0"],
       "archived": ["v7.4", "v7.3", "v7.2", "v7.0", "v6.6", "v6.4", "v6.3", "v6.2", "v6.0", "v5.0", "v4.0", "v3.1", "v3.0", "v2.1"],
       "searchIndex": ["v8.1", "v7.5", "v7.1", "v6.5", "v6.1", "v5.4"]
     },


### PR DESCRIPTION
Do not merge this PR until v8.2 docs are published.