### PR TITLE
Change the cloud doc branch to release-8.1

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -59,10 +59,10 @@ jobs:
           fi
 
           # handle tidb-cloud doc based on specified en/ja doc branch
-          if [ ${{ inputs.repo }} = "pingcap/docs" ] && [ ${{ inputs.branch }} = "release-7.5" ]
+          if [ ${{ inputs.repo }} = "pingcap/docs" ] && [ ${{ inputs.branch }} = "release-8.1" ]
           then
           yarn download:tidb-cloud:en --ref ${{ inputs.branch }}
-          elif [ ${{ inputs.repo }} = "pingcap/docs" ] && [ ${{ inputs.branch }} = "i18n-ja-release-7.5" ]
+          elif [ ${{ inputs.repo }} = "pingcap/docs" ] && [ ${{ inputs.branch }} = "i18n-ja-release-8.1" ]
           then
           yarn download:tidb-cloud:ja --ref ${{ inputs.branch }}
           fi

--- a/docs.json
+++ b/docs.json
@@ -148,7 +148,7 @@
       "archived": ["v1.1", "v1.0"]
     },
     "tidbcloud": {
-      "target": "release-7.5",
+      "target": "release-8.1",
       "languages": {
         "en": {
           "repo": "pingcap/docs",


### PR DESCRIPTION
As the default version for new TiDB Dedicated clusters has been updated to v8.1.0, this PR updates the source of Cloud docs to release-8.1