### PR TITLE
DNM: add release-8.5 as LTS for TiDB

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -42,14 +42,14 @@ jobs:
           mkdir -p ./preview/markdown-pages/zh/tidb
 
           cp -rip ./main/markdown-pages/en/tidb/master ./preview/markdown-pages/en/tidb/master
-          cp -rip ./main/markdown-pages/en/tidb/release-8.1 ./preview/markdown-pages/en/tidb/release-8.1
+          cp -rip ./main/markdown-pages/en/tidb/release-8.5 ./preview/markdown-pages/en/tidb/release-8.5
           cp -rip ./main/markdown-pages/en/tidbcloud ./preview/markdown-pages/en/
 
-          cp -rip ./main/markdown-pages/zh/tidb/release-8.1 ./preview/markdown-pages/zh/tidb/release-8.1
+          cp -rip ./main/markdown-pages/zh/tidb/release-8.5 ./preview/markdown-pages/zh/tidb/release-8.5
           cp -rip ./main/markdown-pages/zh/tidb/master ./preview/markdown-pages/zh/tidb/master
 
           cp -rip ./main/markdown-pages/ja/tidb/master ./preview/markdown-pages/ja/tidb/master
-          cp -rip ./main/markdown-pages/ja/tidb/release-8.1 ./preview/markdown-pages/ja/tidb/release-8.1
+          cp -rip ./main/markdown-pages/ja/tidb/release-8.5 ./preview/markdown-pages/ja/tidb/release-8.5
           cp -rip ./main/markdown-pages/ja/tidbcloud ./preview/markdown-pages/ja/
 
       - name: Git commit and push

--- a/docs.json
+++ b/docs.json
@@ -1,12 +1,13 @@
 {
   "docs": {
     "tidb": {
-      "stable": "release-8.1",
+      "stable": "release-8.5",
       "languages": {
         "en": {
           "repo": "pingcap/docs",
           "versions": [
             "master",
+            "release-8.5",
             "release-8.4",
             "release-8.3",
             "release-8.2",
@@ -23,6 +24,7 @@
           "repo": "pingcap/docs-cn",
           "versions": [
             "master",
+            "release-8.5",
             "release-8.4",
             "release-8.3",
             "release-8.2",
@@ -38,6 +40,7 @@
         "ja": {
           "repo": "pingcap/docs",
           "versions": [
+            "release-8.5",
             "release-8.2",
             "release-8.1",
             "release-7.5",
@@ -96,8 +99,8 @@
         "v2.1"
       ],
       "searchIndex": {
-        "en": ["v8.4", "v8.1"],
-        "zh": ["v8.4", "v8.1", "v7.5", "v6.5", "v5.4"]
+        "en": ["v8.5", "v8.1"],
+        "zh": ["v8.5", "v8.1", "v7.5", "v6.5", "v5.4"]
       }
     },
     "tidb-data-migration": {

--- a/scripts/download-tidb-en.sh
+++ b/scripts/download-tidb-en.sh
@@ -1,4 +1,5 @@
 yarn download:tidb:en
+yarn download:tidb:en --ref release-8.5
 yarn download:tidb:en --ref release-8.4
 yarn download:tidb:en --ref release-8.3
 yarn download:tidb:en --ref release-8.2

--- a/scripts/download-tidb-zh.sh
+++ b/scripts/download-tidb-zh.sh
@@ -1,4 +1,5 @@
 yarn download:tidb:zh
+yarn download:tidb:zh --ref release-8.5
 yarn download:tidb:zh --ref release-8.4
 yarn download:tidb:zh --ref release-8.3
 yarn download:tidb:zh --ref release-8.2


### PR DESCRIPTION
Add release-8.5 for TiDB docs and set it as stable

Do not merge this PR until the installation package of v8.5 is published. 