### PR TITLE
Change the cloud doc branch to release-8.5

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,8 +23,8 @@ on:
         required: false
 
 env:
-  JA_CLOUD_BRANCH: i18n-ja-release-8.1
-  ZH_CLOUD_BRANCH: i18n-zh-release-8.1
+  JA_CLOUD_BRANCH: i18n-ja-release-8.5
+  ZH_CLOUD_BRANCH: i18n-zh-release-8.5
 
 concurrency: ${{ github.workflow }}-${{ inputs.repo }}-${{ inputs.branch }}
 
@@ -74,7 +74,7 @@ jobs:
           fi
 
           # handle tidb-cloud doc based on specified en doc branch
-          if [ ${{ inputs.repo }} = "pingcap/docs" ] && [ ${{ inputs.branch }} = "release-8.1" ]
+          if [ ${{ inputs.repo }} = "pingcap/docs" ] && [ ${{ inputs.branch }} = "release-8.5" ]
           then
           yarn download:tidb-cloud:en --ref ${{ inputs.branch }}
           fi

--- a/docs.json
+++ b/docs.json
@@ -146,7 +146,7 @@
       "archived": ["v1.2", "v1.1", "v1.0"]
     },
     "tidbcloud": {
-      "target": "release-8.1",
+      "target": "release-8.5",
       "languages": {
         "en": {
           "repo": "pingcap/docs",


### PR DESCRIPTION
This PR change the cloud doc branch to release-8.5 as the default version of new TiDB Cloud Dedicated clusters will be upgraded to v8.5.2.