### PR TITLE
archive: add TiDB v5.4 to the doc list

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -208,10 +208,6 @@
       }
     }
   },
-  "redirect": {
-    "/ja/tidb/v6.2/*": "https://docs-archive.pingcap.com/ja/tidb/v6.2/*",
-    "/ja/tidb/v6.3/*": "https://docs-archive.pingcap.com/ja/tidb/v6.3/*"
-  },
   "ignore": [
     ".circleci",
     ".github",

--- a/docs.json
+++ b/docs.json
@@ -12,8 +12,7 @@
             "release-7.5",
             "release-7.1",
             "release-6.5",
-            "release-6.1",
-            "release-5.4"
+            "release-6.1"
           ]
         },
         "zh": {
@@ -25,8 +24,7 @@
             "release-7.5",
             "release-7.1",
             "release-6.5",
-            "release-6.1",
-            "release-5.4"
+            "release-6.1"
           ]
         },
         "ja": {
@@ -37,8 +35,7 @@
             "release-7.5",
             "release-7.1",
             "release-6.5",
-            "release-6.1",
-            "release-5.4"
+            "release-6.1"
           ]
         }
       },
@@ -84,6 +81,7 @@
         "v6.3",
         "v6.2",
         "v6.0",
+        "v5.4",
         "v5.3",
         "v5.2",
         "v5.1",
@@ -121,7 +119,7 @@
           "repo": "pingcap/docs-tidb-operator",
           "path": "en",
           "versions": [
-            "master",
+            "main",
             "release-2.0",
             "release-1.6",
             "release-1.5",
@@ -133,7 +131,7 @@
           "repo": "pingcap/docs-tidb-operator",
           "path": "zh",
           "versions": [
-            "master",
+            "main",
             "release-2.0",
             "release-1.6",
             "release-1.5",
@@ -146,7 +144,7 @@
       "archived": ["v1.2", "v1.1", "v1.0"]
     },
     "tidbcloud": {
-      "target": "release-8.1",
+      "target": "release-8.5",
       "languages": {
         "en": {
           "repo": "pingcap/docs",
@@ -184,6 +182,12 @@
           },
           {
             "id": "v1beta1",
+            "pathname": "v1beta1/dedicated",
+            "production": "https://docs-download.pingcap.com/api/tidbcloud-oas-v1beta1-dedicated.swagger.json",
+            "preview": "https://docs-download.pingcap.com/api/preview-tidbcloud-oas-v1beta1-dedicated.swagger.json"
+          },
+          {
+            "id": "v1beta1",
             "pathname": "v1beta1/iam",
             "production": "https://docs-download.pingcap.com/api/tidbcloud-oas-v1beta1-iam.swagger.json",
             "preview": "https://docs-download.pingcap.com/api/preview-tidbcloud-oas-v1beta1-iam.swagger.json"
@@ -193,10 +197,20 @@
             "pathname": "v1beta1/msp",
             "production": "https://docs-download.pingcap.com/api/tidbcloud-oas-v1beta1-msp.json",
             "preview": "https://docs-download.pingcap.com/api/preview-tidbcloud-oas-v1beta1-msp.json"
+          },
+          {
+            "id": "v1beta1",
+            "pathname": "v1beta1/serverless",
+            "production": "https://docs-download.pingcap.com/api/tidbcloud-oas-v1beta1-serverless.swagger.json",
+            "preview": "https://docs-download.pingcap.com/api/preview-tidbcloud-oas-v1beta1-serverless.swagger.json"
           }
         ]
       }
     }
+  },
+  "redirect": {
+    "/ja/tidb/v6.2/*": "https://docs-archive.pingcap.com/ja/tidb/v6.2/*",
+    "/ja/tidb/v6.3/*": "https://docs-archive.pingcap.com/ja/tidb/v6.3/*"
   },
   "ignore": [
     ".circleci",

--- a/markdown-pages/en/tidb/_docHome.md
+++ b/markdown-pages/en/tidb/_docHome.md
@@ -34,6 +34,7 @@ hide_leftNav: true
 | v6.3 (DMR) | [TiDB v6.3 documentation](https://docs-archive.pingcap.com/tidb/v6.3/) | February 24, 2023 |
 | v6.2 (DMR) | [TiDB v6.2 documentation](https://docs-archive.pingcap.com/tidb/v6.2/) | January 31, 2023 |
 | v6.0 (DMR) | [TiDB v6.0 documentation](https://docs-archive.pingcap.com/tidb/v6.0/) | January 31, 2023 |
+| v5.4       | [TiDB v5.4 documentation](https://docs-archive.pingcap.com/tidb/v5.4/) | April 24, 2026 |
 | v5.3       | [TiDB v5.3 documentation](https://docs-archive.pingcap.com/tidb/v5.3/) | December 30, 2024 |
 | v5.2       | [TiDB v5.2 documentation](https://docs-archive.pingcap.com/tidb/v5.2/) | August 30, 2024 |
 | v5.1       | [TiDB v5.1 documentation](https://docs-archive.pingcap.com/tidb/v5.1/) | July 19, 2024 |

--- a/markdown-pages/zh/tidb/_docHome.md
+++ b/markdown-pages/zh/tidb/_docHome.md
@@ -34,6 +34,7 @@ hide_leftNav: true
 | v6.3 (DMR) | [TiDB v6.3 文档](https://docs-archive.pingcap.com/zh/tidb/v6.3) | 2023 年 2 月 24 日  |
 | v6.2 (DMR) | [TiDB v6.2 文档](https://docs-archive.pingcap.com/zh/tidb/v6.2) | 2023 年 1 月 31 日  |
 | v6.0 (DMR) | [TiDB v6.0 文档](https://docs-archive.pingcap.com/zh/tidb/v6.0) | 2023 年 1 月 31 日  |
+| v5.4       | [TiDB v5.4 文档](https://docs-archive.pingcap.com/zh/tidb/v5.4/) | 2026 年 4 月 24 日 |
 | v5.3       | [TiDB v5.3 文档](https://docs-archive.pingcap.com/zh/tidb/v5.3) | 2024 年 12 月 30 日 |
 | v5.2       | [TiDB v5.2 文档](https://docs-archive.pingcap.com/zh/tidb/v5.2) | 2024 年 8 月 30 日 |
 | v5.1       | [TiDB v5.1 文档](https://docs-archive.pingcap.com/zh/tidb/v5.1) | 2024 年 7 月 19 日 |

--- a/markdown-pages/zh/tidb/_docHome.md
+++ b/markdown-pages/zh/tidb/_docHome.md
@@ -34,7 +34,7 @@ hide_leftNav: true
 | v6.3 (DMR) | [TiDB v6.3 文档](https://docs-archive.pingcap.com/zh/tidb/v6.3) | 2023 年 2 月 24 日  |
 | v6.2 (DMR) | [TiDB v6.2 文档](https://docs-archive.pingcap.com/zh/tidb/v6.2) | 2023 年 1 月 31 日  |
 | v6.0 (DMR) | [TiDB v6.0 文档](https://docs-archive.pingcap.com/zh/tidb/v6.0) | 2023 年 1 月 31 日  |
-| v5.4       | [TiDB v5.4 文档](https://docs-archive.pingcap.com/zh/tidb/v5.4/) | 2026 年 4 月 24 日 |
+| v5.4       | [TiDB v5.4 文档](https://docs-archive.pingcap.com/zh/tidb/v5.4) | 2026 年 4 月 24 日 |
 | v5.3       | [TiDB v5.3 文档](https://docs-archive.pingcap.com/zh/tidb/v5.3) | 2024 年 12 月 30 日 |
 | v5.2       | [TiDB v5.2 文档](https://docs-archive.pingcap.com/zh/tidb/v5.2) | 2024 年 8 月 30 日 |
 | v5.1       | [TiDB v5.1 文档](https://docs-archive.pingcap.com/zh/tidb/v5.1) | 2024 年 7 月 19 日 |


### PR DESCRIPTION
### What changed?
- Replace `docs.json` in the `archive` branch with the latest version from PR #133
- Add the TiDB v5.4 archive entry to `markdown-pages/en/tidb/_docHome.md`
- Add the TiDB v5.4 archive entry to `markdown-pages/zh/tidb/_docHome.md`

### Why?
- Archive TiDB v5.4 in the docs staging archive site
- Keep the archive branch metadata and archive home pages aligned

### Validation
- Verified `docs.json` exactly matches the latest file from branch `archive-5.4` / PR #133
- Ran `jq empty docs.json`
- Reviewed the diff for the two `_docHome.md` updates

### Reference
- https://github.com/pingcap/docs-staging/pull/119
- https://github.com/pingcap/docs-staging/pull/133
