### PR TITLE
fix archive docs build errors

### DIFF
--- a/markdown-pages/en/tidb/release-6.6/sql-statements/sql-statement-alter-resource-group.md
+++ b/markdown-pages/en/tidb/release-6.6/sql-statements/sql-statement-alter-resource-group.md
@@ -18,21 +18,21 @@ The `ALTER RESOURCE GROUP` statement is used to modify a resource group in a dat
 ## Synopsis
 
 ```ebnf+diagram
-AlterResourceGroupStmt:
+AlterResourceGroupStmt ::=
    "ALTER" "RESOURCE" "GROUP" IfExists ResourceGroupName ResourceGroupOptionList
 
 IfExists ::=
     ('IF' 'EXISTS')?
 
-ResourceGroupName:
+ResourceGroupName ::=
    Identifier
 
-ResourceGroupOptionList:
+ResourceGroupOptionList ::=
     DirectResourceGroupOption
 |   ResourceGroupOptionList DirectResourceGroupOption
 |   ResourceGroupOptionList ',' DirectResourceGroupOption
 
-DirectResourceGroupOption:
+DirectResourceGroupOption ::=
     "RU_PER_SEC" EqOpt stringLit
 |   "BURSTABLE"
 

--- a/markdown-pages/en/tidb/release-6.6/sql-statements/sql-statement-create-resource-group.md
+++ b/markdown-pages/en/tidb/release-6.6/sql-statements/sql-statement-create-resource-group.md
@@ -18,21 +18,21 @@ You can use the `CREATE RESOURCE GROUP` statement to create a resource group.
 ## Synopsis
 
 ```ebnf+diagram
-CreateResourceGroupStmt:
+CreateResourceGroupStmt ::=
    "CREATE" "RESOURCE" "GROUP" IfNotExists ResourceGroupName ResourceGroupOptionList
 
 IfNotExists ::=
     ('IF' 'NOT' 'EXISTS')?
 
-ResourceGroupName:
+ResourceGroupName ::=
    Identifier
 
-ResourceGroupOptionList:
+ResourceGroupOptionList ::=
     DirectResourceGroupOption
 |   ResourceGroupOptionList DirectResourceGroupOption
 |   ResourceGroupOptionList ',' DirectResourceGroupOption
 
-DirectResourceGroupOption:
+DirectResourceGroupOption ::=
     "RU_PER_SEC" EqOpt stringLit
 |   "BURSTABLE"
 

--- a/markdown-pages/en/tidb/release-6.6/sql-statements/sql-statement-drop-resource-group.md
+++ b/markdown-pages/en/tidb/release-6.6/sql-statements/sql-statement-drop-resource-group.md
@@ -18,13 +18,13 @@ You can use the `DROP RESOURCE GROUP` statement to drop a resource group.
 ## Synopsis
 
 ```ebnf+diagram
-DropResourceGroupStmt:
+DropResourceGroupStmt ::=
     "DROP" "RESOURCE" "GROUP" IfExists ResourceGroupName
 
 IfExists ::=
     ('IF' 'EXISTS')?
 
-ResourceGroupName:
+ResourceGroupName ::=
     Identifier
 ```
 

--- a/markdown-pages/ja/tidb/release-5.4/TOC.md
+++ b/markdown-pages/ja/tidb/release-5.4/TOC.md
@@ -548,7 +548,7 @@
             -   [`KILL [TIDB]`](/sql-statements/sql-statement-kill.md)
             -   [`LOAD DATA`](/sql-statements/sql-statement-load-data.md)
             -   [`LOAD STATS`](/sql-statements/sql-statement-load-stats.md)
-            -   [`LOCK TABLES`と`UNLOCK TABLES`](/sql-statements/sql-statement-lock-tables-and-unlock-tables.md)
+            -   [`[LOCK|UNLOCK] TABLES`](/sql-statements/sql-statement-lock-tables-and-unlock-tables.md)
             -   [`MODIFY COLUMN`](/sql-statements/sql-statement-modify-column.md)
             -   [`PREPARE`](/sql-statements/sql-statement-prepare.md)
             -   [`RECOVER TABLE`](/sql-statements/sql-statement-recover-table.md)

--- a/markdown-pages/ja/tidb/release-5.4/TOC.md
+++ b/markdown-pages/ja/tidb/release-5.4/TOC.md
@@ -548,7 +548,7 @@
             -   [`KILL [TIDB]`](/sql-statements/sql-statement-kill.md)
             -   [`LOAD DATA`](/sql-statements/sql-statement-load-data.md)
             -   [`LOAD STATS`](/sql-statements/sql-statement-load-stats.md)
-            -   [`LOCK TABLES`と<code>UNLOCK TABLES</code>](/sql-statements/sql-statement-lock-tables-and-unlock-tables.md)
+            -   [`LOCK TABLES`と`UNLOCK TABLES`](/sql-statements/sql-statement-lock-tables-and-unlock-tables.md)
             -   [`MODIFY COLUMN`](/sql-statements/sql-statement-modify-column.md)
             -   [`PREPARE`](/sql-statements/sql-statement-prepare.md)
             -   [`RECOVER TABLE`](/sql-statements/sql-statement-recover-table.md)

--- a/markdown-pages/zh/tidb/release-6.6/sql-statements/sql-statement-alter-resource-group.md
+++ b/markdown-pages/zh/tidb/release-6.6/sql-statements/sql-statement-alter-resource-group.md
@@ -10,21 +10,21 @@ summary: TiDB 数据库中 ALTER RESOURCE GROUP 的使用概况。
 ## 语法图
 
 ```ebnf+diagram
-AlterResourceGroupStmt:
+AlterResourceGroupStmt ::=
    "ALTER" "RESOURCE" "GROUP" IfExists ResourceGroupName ResourceGroupOptionList
 
 IfExists ::=
     ('IF' 'EXISTS')?
 
-ResourceGroupName:
+ResourceGroupName ::=
    Identifier
 
-ResourceGroupOptionList:
+ResourceGroupOptionList ::=
     DirectResourceGroupOption
 |   ResourceGroupOptionList DirectResourceGroupOption
 |   ResourceGroupOptionList ',' DirectResourceGroupOption
 
-DirectResourceGroupOption:
+DirectResourceGroupOption ::=
     "RU_PER_SEC" EqOpt stringLit
 |   "BURSTABLE"
 

--- a/markdown-pages/zh/tidb/release-6.6/sql-statements/sql-statement-create-resource-group.md
+++ b/markdown-pages/zh/tidb/release-6.6/sql-statements/sql-statement-create-resource-group.md
@@ -10,21 +10,21 @@ summary: TiDB 数据库中 CREATE RESOURCE GROUP 的使用概况。
 ## 语法图
 
 ```ebnf+diagram
-CreateResourceGroupStmt:
+CreateResourceGroupStmt ::=
    "CREATE" "RESOURCE" "GROUP" IfNotExists ResourceGroupName ResourceGroupOptionList
 
 IfNotExists ::=
     ('IF' 'NOT' 'EXISTS')?
 
-ResourceGroupName:
+ResourceGroupName ::=
    Identifier
 
-ResourceGroupOptionList:
+ResourceGroupOptionList ::=
     DirectResourceGroupOption
 |   ResourceGroupOptionList DirectResourceGroupOption
 |   ResourceGroupOptionList ',' DirectResourceGroupOption
 
-DirectResourceGroupOption:
+DirectResourceGroupOption ::=
     "RU_PER_SEC" EqOpt stringLit
 |   "BURSTABLE"
 

--- a/markdown-pages/zh/tidb/release-6.6/sql-statements/sql-statement-drop-resource-group.md
+++ b/markdown-pages/zh/tidb/release-6.6/sql-statements/sql-statement-drop-resource-group.md
@@ -10,13 +10,13 @@ summary: TiDB 数据库中 DROP RESOURCE GROUP 的使用概况。
 ## 语法图
 
 ```ebnf+diagram
-DropResourceGroupStmt:
+DropResourceGroupStmt ::=
     "DROP" "RESOURCE" "GROUP" IfExists ResourceGroupName
 
 IfExists ::=
     ('IF' 'EXISTS')?
 
-ResourceGroupName:
+ResourceGroupName ::=
     Identifier
 ```
 


### PR DESCRIPTION
## Summary

Fix https://github.com/pingcap/website-docs/actions/runs/24876607138/job/72834589465

## Root Cause

The archive website build failed on generated docs content for two content-shape issues:

1. The TiDB v6.6 resource group statement pages used `RuleName:` inside `ebnf+diagram` blocks, but the `website-docs` syntax diagram parser requires `RuleName ::=`.
2. A Japanese v5.4 TOC entry used raw `<code>` inside link text, which `website-docs` rejects while building TOC navigation.

## Validation

- `website-docs` `syntax-diagram` plugin check for the six edited v6.6 resource group pages
- `website-docs` `mdxAstToToc` check for all 61 `TOC*.md` files
- `git diff --check upstream/archive..HEAD`
