### PR TITLE
workflow: sync tidb-cloud-lake from release-8.5

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -54,6 +54,25 @@ jobs:
         env:
           GITHUB_AUTHORIZATION_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
+          sync_tidb_cloud_lake() {
+            local source_root="$1"
+            local target_root="./markdown-pages/en/tidb-cloud-lake/master"
+
+            mkdir -p "${target_root}"
+            rm -rf "${target_root}/tidb-cloud-lake"
+            rm -f "${target_root}/TOC-tidb-cloud-lake.md"
+
+            if [ -d "${source_root}/tidb-cloud-lake" ]
+            then
+              mv "${source_root}/tidb-cloud-lake" "${target_root}/"
+            fi
+
+            if [ -f "${source_root}/TOC-tidb-cloud-lake.md" ]
+            then
+              mv "${source_root}/TOC-tidb-cloud-lake.md" "${target_root}/"
+            fi
+          }
+
           # handle zh auto translated docs branch(only cloud)
           if [ ${{ inputs.repo }} = "pingcap/docs" ] && [ ${{ inputs.branch }} = ${{ env.ZH_CLOUD_BRANCH }} ]
           then
@@ -74,6 +93,7 @@ jobs:
           then
           yarn download:tidb-cloud:en --ref ${{ inputs.branch }}
           yarn download ${{ inputs.repo }} --ref ${{ inputs.branch }}
+          sync_tidb_cloud_lake "./markdown-pages/en/tidb/${{ inputs.branch }}"
           exit 0
           fi
 
@@ -92,8 +112,28 @@ jobs:
         env:
           GITHUB_AUTHORIZATION_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
+          sync_tidb_cloud_lake() {
+            local source_root="$1"
+            local target_root="./markdown-pages/en/tidb-cloud-lake/master"
+
+            mkdir -p "${target_root}"
+            rm -rf "${target_root}/tidb-cloud-lake"
+            rm -f "${target_root}/TOC-tidb-cloud-lake.md"
+
+            if [ -d "${source_root}/tidb-cloud-lake" ]
+            then
+              mv "${source_root}/tidb-cloud-lake" "${target_root}/"
+            fi
+
+            if [ -f "${source_root}/TOC-tidb-cloud-lake.md" ]
+            then
+              mv "${source_root}/TOC-tidb-cloud-lake.md" "${target_root}/"
+            fi
+          }
+
           sudo rm -fr ./markdown-pages/*
           yarn download:tidb:en:all
+          sync_tidb_cloud_lake "./markdown-pages/en/tidb/${{ env.EN_CLOUD_BRANCH }}"
           yarn download:tidb-cloud:en
           yarn download:tidb:zh:all
           yarn download:tidb:ja:all

--- a/markdown-pages/en/tidb-cloud-lake/master/tidb-cloud-lake/_index.md
+++ b/markdown-pages/en/tidb-cloud-lake/master/tidb-cloud-lake/_index.md
@@ -1,0 +1,116 @@
+---
+title: TiDB Cloud Lake Documentation
+hide_sidebar: true
+hide_commit: true
+summary: TiDB Cloud Lake is a cloud-native data warehouse service for analytics workloads. It separates compute and storage, and supports ANSI SQL, semi-structured data processing, and AI-oriented workflows.
+---
+
+<LearningPathContainer platform="tidb-cloud" title="TiDB Cloud Lake" subTitle="TiDB Cloud Lake is a cloud-native data warehouse service for analytics workloads. It separates compute and storage, and supports ANSI SQL, semi-structured data processing, and AI-oriented workflows.">
+
+<LearningPath label="Learn" icon="cloud1">
+
+[TiDB Cloud Lake Overview](https://docs.tidb.io/tidbcloudlake/lake-overview/)
+
+[Architecture](https://docs.tidb.io/tidbcloudlake/tidb-cloud-lake-architecture/)
+
+[Editions](https://docs.tidb.io/tidbcloudlake/editions/)
+
+</LearningPath>
+
+<LearningPath label="Try" icon="cloud5">
+
+[Quick Start](https://docs.tidb.io/tidbcloudlake/lake-quick-start/)
+
+[Migrate from Snowflake](https://docs.tidb.io/tidbcloudlake/migrate-from-snowflake/)
+
+[Ingest JSON Logs with Vector](https://docs.tidb.io/tidbcloudlake/ingest-json-logs-with-vector-cloud/)
+
+</LearningPath>
+
+<LearningPath label="Connect" icon="doc8">
+
+[Connection Overview](https://docs.tidb.io/tidbcloudlake/connection-overview/)
+
+[Connect Using LakeSQL](https://docs.tidb.io/tidbcloudlake/connect-using-lakesql/)
+
+[Connect Using Golang](https://docs.tidb.io/tidbcloudlake/connect-using-golang/)
+
+[Connect with Tableau](https://docs.tidb.io/tidbcloudlake/tableau/)
+
+[Connect with AWS PrivateLink](https://docs.tidb.io/tidbcloudlake/connect-with-aws-privatelink/)
+
+</LearningPath>
+
+<LearningPath label="Integrate" icon="cloud4">
+
+[Data Integration Overview](https://docs.tidb.io/tidbcloudlake/data-integration-overview/)
+
+[Supported Data Sources](https://docs.tidb.io/tidbcloudlake/data-sources/)
+
+[Integration Tasks](https://docs.tidb.io/tidbcloudlake/integration-tasks/)
+
+</LearningPath>
+
+<LearningPath label="Load" icon="cloud3">
+
+[Work with Stages](https://docs.tidb.io/tidbcloudlake/stage-overview/)
+
+[Load from Files](https://docs.tidb.io/tidbcloudlake/load-from-files/)
+
+[Query & Transform Data](https://docs.tidb.io/tidbcloudlake/query-stage/)
+
+[Continuous Data Pipelines](https://docs.tidb.io/tidbcloudlake/continuous-data-pipelines/)
+
+</LearningPath>
+
+<LearningPath label="Analyze" icon="cloud6">
+
+[Multimodal Data Analytics](https://docs.tidb.io/tidbcloudlake/multimodal-data-analytics/)
+
+[SQL Analytics](https://docs.tidb.io/tidbcloudlake/sql-analytics/)
+
+[Vector Search](https://docs.tidb.io/tidbcloudlake/vector-search-guide/)
+
+</LearningPath>
+
+<LearningPath label="Operate" icon="tidb-cloud-tune">
+
+[Manage Costs](https://docs.tidb.io/tidbcloudlake/manage-costs/)
+
+[Monitor Usage](https://docs.tidb.io/tidbcloudlake/monitor-usage/)
+
+[AI-Powered Features](https://docs.tidb.io/tidbcloudlake/ai-powered-features/)
+
+[Performance Tuning](https://docs.tidb.io/tidbcloudlake/performance-optimization/)
+
+[Troubleshooting](https://docs.tidb.io/tidbcloudlake/troubleshooting/)
+
+</LearningPath>
+
+<LearningPath label="Security" icon="users">
+
+[Security & Reliability](https://docs.tidb.io/tidbcloudlake/security-reliability/)
+
+[Access Control](https://docs.tidb.io/tidbcloudlake/access-control/)
+
+[Data Protection Policies](https://docs.tidb.io/tidbcloudlake/data-protection-policies/)
+
+[Authenticate with AWS IAM Role](https://docs.tidb.io/tidbcloudlake/authenticate-with-aws-iam-role/)
+
+[Compliance & Security](https://docs.tidb.io/tidbcloudlake/compliance-security/)
+
+</LearningPath>
+
+<LearningPath label="Reference" icon="cloud-dev">
+
+[SQL Reference](https://docs.tidb.io/tidbcloudlake/sql-statements-overview/)
+
+[Pricing & Billing](https://docs.tidb.io/tidbcloudlake/pricing-billing/)
+
+[Data Ingestion Benchmark](https://docs.tidb.io/tidbcloudlake/benchmark-data-ingestion/)
+
+[Support Services](https://docs.tidb.io/tidbcloudlake/support-services/)
+
+</LearningPath>
+
+</LearningPathContainer>


### PR DESCRIPTION
## Summary
- sync pingcap/docs release-8.5 branch's tidb-cloud-lake docs into markdown-pages/en/tidb-cloud-lake/master
- sync TOC-tidb-cloud-lake.md into the same target directory
- keep those files out of markdown-pages/en/tidb/release-8.5, including during full updates

## Testing
- parsed .github/workflows/update.yml successfully with a YAML loader
- ran git diff --check -- .github/workflows/update.yml