### PR TITLE
main: archive v6.1 docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -231,6 +231,7 @@
   },
   "redirect": {
     "/ja/tidb/v5.4/*": "https://docs-archive.pingcap.com/ja/tidb/v5.4/*",
+    "/ja/tidb/v6.1/*": "https://docs-archive.pingcap.com/ja/tidb/v6.1/*",
     "/ja/tidb/v6.2/*": "https://docs-archive.pingcap.com/ja/tidb/v6.2/*",
     "/ja/tidb/v6.3/*": "https://docs-archive.pingcap.com/ja/tidb/v6.3/*"
   },

--- a/docs.json
+++ b/docs.json
@@ -11,8 +11,7 @@
             "release-8.1",
             "release-7.5",
             "release-7.1",
-            "release-6.5",
-            "release-6.1"
+            "release-6.5"
           ]
         },
         "zh": {
@@ -23,8 +22,7 @@
             "release-8.1",
             "release-7.5",
             "release-7.1",
-            "release-6.5",
-            "release-6.1"
+            "release-6.5"
           ]
         },
         "ja": {
@@ -34,8 +32,7 @@
             "release-8.1",
             "release-7.5",
             "release-7.1",
-            "release-6.5",
-            "release-6.1"
+            "release-6.5"
           ]
         }
       },
@@ -80,6 +77,7 @@
         "v6.4",
         "v6.3",
         "v6.2",
+        "v6.1",
         "v6.0",
         "v5.4",
         "v5.3",


### PR DESCRIPTION
### What is changed?

- Remove `release-6.1` from the TiDB docs version lists for `en`, `zh`, and `ja`.
- Add `v6.1` to the archived TiDB doc list.

### Related context

- Archive date: `2026-07-10`
