### PR TITLE
archive: add TiDB v6.1 to the doc list

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11,8 +11,7 @@
             "release-8.1",
             "release-7.5",
             "release-7.1",
-            "release-6.5",
-            "release-6.1"
+            "release-6.5"
           ]
         },
         "zh": {
@@ -23,8 +22,7 @@
             "release-8.1",
             "release-7.5",
             "release-7.1",
-            "release-6.5",
-            "release-6.1"
+            "release-6.5"
           ]
         },
         "ja": {
@@ -34,8 +32,7 @@
             "release-8.1",
             "release-7.5",
             "release-7.1",
-            "release-6.5",
-            "release-6.1"
+            "release-6.5"
           ]
         }
       },
@@ -80,6 +77,7 @@
         "v6.4",
         "v6.3",
         "v6.2",
+        "v6.1",
         "v6.0",
         "v5.4",
         "v5.3",
@@ -203,8 +201,31 @@
             "pathname": "v1beta1/serverless",
             "production": "https://docs-download.pingcap.com/api/tidbcloud-oas-v1beta1-serverless.swagger.json",
             "preview": "https://docs-download.pingcap.com/api/preview-tidbcloud-oas-v1beta1-serverless.swagger.json"
+          },
+          {
+            "id": "v1beta2",
+            "pathname": "v1beta2/premium",
+            "production": "https://docs-download.pingcap.com/api/tidbcloud-oas-v1beta2-premium.swagger.json",
+            "preview": "https://docs-download.pingcap.com/api/preview-tidbcloud-oas-v1beta2-premium.swagger.json"
           }
         ]
+      }
+    },
+    "tidb-cloud-lake": {
+      "target": "release-8.5",
+      "languages": {
+        "en": {
+          "repo": "pingcap/docs",
+          "versions": ["master"]
+        },
+        "zh": {
+          "repo": "pingcap/docs",
+          "versions": ["master"]
+        },
+        "ja": {
+          "repo": "pingcap/docs",
+          "versions": ["master"]
+        }
       }
     }
   },

--- a/markdown-pages/en/tidb/_docHome.md
+++ b/markdown-pages/en/tidb/_docHome.md
@@ -33,6 +33,7 @@ hide_leftNav: true
 | v6.4 (DMR) | [TiDB v6.4 documentation](https://docs-archive.pingcap.com/tidb/v6.4/) | April 6, 2023 |
 | v6.3 (DMR) | [TiDB v6.3 documentation](https://docs-archive.pingcap.com/tidb/v6.3/) | February 24, 2023 |
 | v6.2 (DMR) | [TiDB v6.2 documentation](https://docs-archive.pingcap.com/tidb/v6.2/) | January 31, 2023 |
+| v6.1       | [TiDB v6.1 documentation](https://docs-archive.pingcap.com/tidb/v6.1/) | July 10, 2026 |
 | v6.0 (DMR) | [TiDB v6.0 documentation](https://docs-archive.pingcap.com/tidb/v6.0/) | January 31, 2023 |
 | v5.4       | [TiDB v5.4 documentation](https://docs-archive.pingcap.com/tidb/v5.4/) | April 24, 2026 |
 | v5.3       | [TiDB v5.3 documentation](https://docs-archive.pingcap.com/tidb/v5.3/) | December 30, 2024 |

--- a/markdown-pages/zh/tidb/_docHome.md
+++ b/markdown-pages/zh/tidb/_docHome.md
@@ -33,6 +33,7 @@ hide_leftNav: true
 | v6.4 (DMR) | [TiDB v6.4 文档](https://docs-archive.pingcap.com/zh/tidb/v6.4) | 2023 年 4 月 6 日   |
 | v6.3 (DMR) | [TiDB v6.3 文档](https://docs-archive.pingcap.com/zh/tidb/v6.3) | 2023 年 2 月 24 日  |
 | v6.2 (DMR) | [TiDB v6.2 文档](https://docs-archive.pingcap.com/zh/tidb/v6.2) | 2023 年 1 月 31 日  |
+| v6.1       | [TiDB v6.1 文档](https://docs-archive.pingcap.com/zh/tidb/v6.1) | 2026 年 7 月 10 日 |
 | v6.0 (DMR) | [TiDB v6.0 文档](https://docs-archive.pingcap.com/zh/tidb/v6.0) | 2023 年 1 月 31 日  |
 | v5.4       | [TiDB v5.4 文档](https://docs-archive.pingcap.com/zh/tidb/v5.4) | 2026 年 4 月 24 日 |
 | v5.3       | [TiDB v5.3 文档](https://docs-archive.pingcap.com/zh/tidb/v5.3) | 2024 年 12 月 30 日 |


### PR DESCRIPTION
### What is changed?

- Sync `docs.json` from the `archive-6.1` branch.
- Remove the top-level `redirect` section from `docs.json` on the `archive` branch.
- Add `v6.1` archive rows to the English and Chinese TiDB archive home pages.

### Related context

- Archive date: `2026-07-10`
