### PR TITLE
revert: archive v6.1 docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11,7 +11,8 @@
             "release-8.1",
             "release-7.5",
             "release-7.1",
-            "release-6.5"
+            "release-6.5",
+            "release-6.1"
           ]
         },
         "zh": {
@@ -22,7 +23,8 @@
             "release-8.1",
             "release-7.5",
             "release-7.1",
-            "release-6.5"
+            "release-6.5",
+            "release-6.1"
           ]
         },
         "ja": {
@@ -32,7 +34,8 @@
             "release-8.1",
             "release-7.5",
             "release-7.1",
-            "release-6.5"
+            "release-6.5",
+            "release-6.1"
           ]
         }
       },
@@ -77,7 +80,6 @@
         "v6.4",
         "v6.3",
         "v6.2",
-        "v6.1",
         "v6.0",
         "v5.4",
         "v5.3",
@@ -231,7 +233,6 @@
   },
   "redirect": {
     "/ja/tidb/v5.4/*": "https://docs-archive.pingcap.com/ja/tidb/v5.4/*",
-    "/ja/tidb/v6.1/*": "https://docs-archive.pingcap.com/ja/tidb/v6.1/*",
     "/ja/tidb/v6.2/*": "https://docs-archive.pingcap.com/ja/tidb/v6.2/*",
     "/ja/tidb/v6.3/*": "https://docs-archive.pingcap.com/ja/tidb/v6.3/*"
   },


### PR DESCRIPTION
### What is changed?

- Revert the changes merged by PR #141 (`main: archive v6.1 docs`).
- Restore the previous `docs-staging` `main` branch content before that merge.

### Why?

- PR #141 was merged by mistake.
